### PR TITLE
错误修复：SQLErrorType枚举类命名错误导致编译错误

### DIFF
--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/enums/SQLErrorType.java
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/enums/SQLErrorType.java
@@ -20,7 +20,7 @@
  */
 package com.streamxhub.streamx.common.enums;
 
-public enum SqlErrorType {
+public enum SQLErrorType {
     /**
      * 基本检验失败(如为null等)
      */
@@ -43,12 +43,12 @@ public enum SqlErrorType {
     ENDS_WITH(5);
     public int errorType;
 
-    SqlErrorType(int errorType) {
+    SQLErrorType(int errorType) {
         this.errorType = errorType;
     }
 
-    public static SqlErrorType of(Integer errorType) {
-        for (SqlErrorType type : values()) {
+    public static SQLErrorType of(Integer errorType) {
+        for (SQLErrorType type : values()) {
             if (type.errorType == errorType) {
                 return type;
             }

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/FlinkSqlController.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/controller/FlinkSqlController.java
@@ -16,7 +16,7 @@
  */
 package com.streamxhub.streamx.console.core.controller;
 
-import com.streamxhub.streamx.common.enums.SqlErrorType;
+import com.streamxhub.streamx.common.enums.SQLErrorType;
 import com.streamxhub.streamx.console.base.domain.RestResponse;
 import com.streamxhub.streamx.console.base.exception.ServiceException;
 import com.streamxhub.streamx.console.core.entity.Application;
@@ -65,7 +65,7 @@ public class FlinkSqlController {
                     .put("start", start)
                     .put("end", end);
             //语法异常
-            if (sqlError.errorType().equals(SqlErrorType.SYNTAX_ERROR)) {
+            if (sqlError.errorType().equals(SQLErrorType.SYNTAX_ERROR)) {
                 String exception = sqlError.exception().replaceAll("[\r\n]", "");
                 if (exception.matches(SQL_SPARSE_FAILED_REGEXP)) {
                     String[] lineColumn = exception

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/FlinkTableHelper.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/FlinkTableHelper.scala
@@ -1,7 +1,7 @@
 package com.streamxhub.streamx.flink.core
 
 import com.streamxhub.streamx.common.conf.ConfigConst.KEY_FLINK_SQL
-import com.streamxhub.streamx.common.enums.SqlErrorType
+import com.streamxhub.streamx.common.enums.SQLErrorType
 import com.streamxhub.streamx.common.util.Logger
 import com.streamxhub.streamx.flink.core.SqlCommand._
 import org.apache.flink.api.java.utils.ParameterTool
@@ -50,7 +50,7 @@ trait FlinkTableHelper extends Logger {
 
   private[streamx] def callSql(sql: String, parameter: ParameterTool, context: TableEnvironment)(implicit callbackFunc: Unit => String = null): Unit = {
     val flinkSql: String = if (sql == null || sql.isEmpty) parameter.get(KEY_FLINK_SQL()) else parameter.get(sql)
-    val sqlEmptyError = SqlError(SqlErrorType.VERIFY_FAILED, "sql is empty", sql).toString
+    val sqlEmptyError = SqlError(SQLErrorType.VERIFY_FAILED, "sql is empty", sql).toString
     require(flinkSql != null && flinkSql.trim.nonEmpty, sqlEmptyError)
 
     def callback(r: String): Unit = {

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/SqlCommandParser.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims-base/src/main/scala/com/streamxhub/streamx/flink/core/SqlCommandParser.scala
@@ -20,7 +20,7 @@
  */
 package com.streamxhub.streamx.flink.core
 
-import com.streamxhub.streamx.common.enums.SqlErrorType
+import com.streamxhub.streamx.common.enums.SQLErrorType
 import com.streamxhub.streamx.common.util.Logger
 import enumeratum.EnumEntry
 
@@ -34,7 +34,7 @@ object SqlCommandParser extends Logger {
   private[this] val WITH_REGEXP = "(WITH|with)\\s*\\(\\s*\\n+((.*)\\s*=(.*)(,|)\\s*\\n+)+\\)".r
 
   def parseSQL(sql: String): List[SqlCommandCall] = {
-    val sqlEmptyError = SqlError(SqlErrorType.VERIFY_FAILED, "sql is empty", sql).toString
+    val sqlEmptyError = SqlError(SQLErrorType.VERIFY_FAILED, "sql is empty", sql).toString
     require(sql != null && sql.trim.nonEmpty, sqlEmptyError)
     val lines = sql.split("\\n").filter(_ != null).filter(_.trim.nonEmpty).filter(!_.startsWith("--"))
     lines match {
@@ -47,14 +47,14 @@ object SqlCommandParser extends Logger {
           if (line.trim.endsWith(";")) {
             parseLine(stmt.toString.trim) match {
               case Some(x) => calls += x
-              case _ => throw new RuntimeException(SqlError(SqlErrorType.UNSUPPORTED_SQL, sql = stmt.toString).toErrorString)
+              case _ => throw new RuntimeException(SqlError(SQLErrorType.UNSUPPORTED_SQL, sql = stmt.toString).toErrorString)
             }
             // clear string builder
             stmt.clear()
           }
         }
         calls.toList match {
-          case Nil => throw new RuntimeException(SqlError(SqlErrorType.ENDS_WITH, sql = sql).toErrorString)
+          case Nil => throw new RuntimeException(SqlError(SQLErrorType.ENDS_WITH, sql = sql).toErrorString)
           case r => r
         }
     }
@@ -290,7 +290,7 @@ case class SqlCommandCall(command: SqlCommand, operands: Array[String]) {
 
 
 case class SqlError(
-                     errorType: SqlErrorType,
+                     errorType: SQLErrorType,
                      exception: String = null,
                      sql: String = null
                    ) {

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.12/src/main/scala/com/streamxhub/streamx/flink/core/SqlValidator.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.12/src/main/scala/com/streamxhub/streamx/flink/core/SqlValidator.scala
@@ -20,7 +20,7 @@
  */
 package com.streamxhub.streamx.flink.core
 
-import com.streamxhub.streamx.common.enums.SqlErrorType
+import com.streamxhub.streamx.common.enums.SQLErrorType
 import com.streamxhub.streamx.common.util.Logger
 import org.apache.calcite.config.Lex
 import org.apache.calcite.sql.parser.SqlParser
@@ -52,7 +52,7 @@ object SqlValidator extends Logger {
         case _ =>
           throw new TableException(
             SqlError(
-              SqlErrorType.UNSUPPORTED_DIALECT,
+              SQLErrorType.UNSUPPORTED_DIALECT,
               s"Unsupported SQL dialect:${tableConfig.getSqlDialect}").toString
           )
       }
@@ -75,7 +75,7 @@ object SqlValidator extends Logger {
         val error = exception.getLocalizedMessage
         val array = error.split(separator)
         return SqlError(
-          SqlErrorType.of(array.head.toInt),
+          SQLErrorType.of(array.head.toInt),
           if (array(1) == "null") null else array(1),
           array.last
         )
@@ -99,14 +99,14 @@ object SqlValidator extends Logger {
           } catch {
             case e: Exception =>
               return SqlError(
-                SqlErrorType.SYNTAX_ERROR,
+                SQLErrorType.SYNTAX_ERROR,
                 e.getLocalizedMessage,
                 sql.trim.replaceFirst(";|$", ";")
               )
             case _: Throwable =>
           }
         case _ => return SqlError(
-          SqlErrorType.UNSUPPORTED_SQL,
+          SQLErrorType.UNSUPPORTED_SQL,
           sql = sql.replaceFirst(";|$", ";")
         )
       }

--- a/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.13/src/main/scala/com/streamxhub/streamx/flink/core/SqlValidator.scala
+++ b/streamx-flink/streamx-flink-shims/streamx-flink-shims_flink-1.13/src/main/scala/com/streamxhub/streamx/flink/core/SqlValidator.scala
@@ -20,7 +20,7 @@
  */
 package com.streamxhub.streamx.flink.core
 
-import com.streamxhub.streamx.common.enums.SqlErrorType
+import com.streamxhub.streamx.common.enums.SQLErrorType
 import com.streamxhub.streamx.common.util.Logger
 import org.apache.calcite.config.Lex
 import org.apache.calcite.sql.parser.SqlParser
@@ -52,7 +52,7 @@ object SqlValidator extends Logger {
         case _ =>
           throw new TableException(
             SqlError(
-              SqlErrorType.UNSUPPORTED_DIALECT,
+              SQLErrorType.UNSUPPORTED_DIALECT,
               s"Unsupported SQL dialect:${tableConfig.getSqlDialect}").toString
           )
       }
@@ -75,7 +75,7 @@ object SqlValidator extends Logger {
         val error = exception.getLocalizedMessage
         val array = error.split(separator)
         return SqlError(
-          SqlErrorType.of(array.head.toInt),
+          SQLErrorType.of(array.head.toInt),
           if (array(1) == "null") null else array(1),
           array.last
         )
@@ -99,14 +99,14 @@ object SqlValidator extends Logger {
           } catch {
             case e: Exception =>
               return SqlError(
-                SqlErrorType.SYNTAX_ERROR,
+                SQLErrorType.SYNTAX_ERROR,
                 e.getLocalizedMessage,
                 sql.trim.replaceFirst(";|$", ";")
               )
             case _: Throwable =>
           }
         case _ => return SqlError(
-          SqlErrorType.UNSUPPORTED_SQL,
+          SQLErrorType.UNSUPPORTED_SQL,
           sql = sql.replaceFirst(";|$", ";")
         )
       }


### PR DESCRIPTION
使用mvn clean install -DskipTests，提示以下错误❌：streamx/streamx-common/src/main/scala/com/streamxhub/streamx/common/enums/SQLErrorType.java:23: 类SqlErrorType是公共的, 应在SqlErrorType.java 的文件中声明

错误类型命名枚举类错误编写导致无法编译，现已提交修复通过编译