### PR TITLE
Temporary building resources recycling for streamx-packer module

### DIFF
--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/PackerResourceGCTask.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/PackerResourceGCTask.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 The StreamX Project
+ * <p>
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.streamxhub.streamx.console.core.task;
+
+import com.streamxhub.streamx.flink.packer.PackerResourceGC;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * author: Al-assad
+ */
+@Slf4j
+@Component
+public class PackerResourceGCTask {
+
+    @Value("${streamx.packer-gc.max-resource-expired-hours:120}")
+    public Integer maxResourceIntervalHours;
+
+    @Scheduled(cron = "${streamx.packer-gc.exec-cron:0 0 0/1 * * ?}")
+    public void collectGarbage() {
+        log.info("[streamx-packer] Starting Packer Resource GC Task.");
+        PackerResourceGC.startGc(maxResourceIntervalHours);
+    }
+
+}

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/PackerResourceGCTask.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/PackerResourceGCTask.java
@@ -11,7 +11,8 @@
  * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
  * <p>
- * Unless required by applicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing\
+ *
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied. See the License for the
@@ -36,7 +37,7 @@ public class PackerResourceGCTask {
     @Value("${streamx.packer-gc.max-resource-expired-hours:120}")
     public Integer maxResourceIntervalHours;
 
-    @Scheduled(cron = "${streamx.packer-gc.exec-cron:0 0 0/1 * * ?}")
+    @Scheduled(cron = "${streamx.packer-gc.exec-cron:0 0 0/6 * * ?}")
     public void collectGarbage() {
         log.info("[streamx-packer] Starting Packer Resource GC Task.");
         PackerResourceGC.startGc(maxResourceIntervalHours);

--- a/streamx-console/streamx-console-service/src/main/resources/application.yml
+++ b/streamx-console/streamx-console-service/src/main/resources/application.yml
@@ -89,6 +89,13 @@ streamx:
         job-status: 2
         cluster-metric: 3
 
+  # packer garbage resources collection configuration
+  packer-gc:
+    # maximum retention time for temporary build resources
+    max-resource-expired-hours: 120
+    # gc task running interval hours
+    exec-cron: 0 0 0/1 * * ?
+
   shiro:
     # token有效期，单位秒
     jwtTimeOut: 86400

--- a/streamx-console/streamx-console-service/src/main/resources/application.yml
+++ b/streamx-console/streamx-console-service/src/main/resources/application.yml
@@ -94,7 +94,7 @@ streamx:
     # maximum retention time for temporary build resources
     max-resource-expired-hours: 120
     # gc task running interval hours
-    exec-cron: 0 0 0/1 * * ?
+    exec-cron: 0 0 0/6 * * ?
 
   shiro:
     # token有效期，单位秒

--- a/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/PackerResourceGC.scala
+++ b/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/PackerResourceGC.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 The StreamX Project
+ * <p>
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.streamxhub.streamx.flink.packer
+
+import com.streamxhub.streamx.common.conf.Workspace
+import com.streamxhub.streamx.common.util.Logger
+import org.apache.commons.io.FileUtils
+
+import java.io.File
+import scala.util.Try
+
+
+/**
+ * Garbage resource collector during packing.
+ */
+object PackerResourceGC extends Logger {
+
+  val appWorkspacePath: String = Workspace.local.APP_WORKSPACE
+
+
+  /**
+   * Start a building legacy resources collection process.
+   *
+   * @param expiredHours Expected expiration time of building resources.
+   */
+  def startGc(expiredHours: Integer): Unit = {
+    val appWorkspace = new File(appWorkspacePath)
+    if (!appWorkspace.exists()) return
+    val evicitedBarrier = System.currentTimeMillis - expiredHours * 3600 * 1000
+
+    // find flink building path that should be evicited, which are based on pattern
+    // matching of filename.
+    val evicitedFiles = appWorkspace.listFiles
+      .filter(_.isDirectory)
+      .filter(_.getName.contains("@"))
+      .flatMap(findLastModifiedOfSubFile)
+      .filter(_._2 < evicitedBarrier)
+      .map(_._1)
+
+    if (evicitedFiles.isEmpty) return
+    logInfo(s"[streamx-packer] Delete expired building resources, ${evicitedFiles.mkString(", ")}")
+    evicitedFiles.foreach(path => Try(FileUtils.deleteDirectory(path)))
+  }
+
+
+  private def findLastModifiedOfSubFile(file: File): Array[(File, Long)] = {
+    val isApplicationMode = file.listFiles.map(_.getName).exists(_.contains(".jar"))
+    if (isApplicationMode)
+      Array(file -> file.listFiles.map(_.lastModified).max)
+    else
+      file.listFiles.filter(_.isDirectory)
+        .map(subFile => subFile -> subFile.listFiles.map(_.lastModified).max)
+  }
+
+
+}


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:
`streamx-packer` does not implement thorough temporary file recycling when building fat-jar, and more and more temporary build files will be accumulated under `app_workspace/workspace` over time.

### What is changed and how it works?

How it Works:

The gc task is a timed deletion based on file pathname matching, which  is executed once every 6 hours, and the file retention time is 120 hours by default (the user can customize this expiration time). Delayed expiration makes it easier for users to debug the use of these build resources.

### Release Expectation: 
This feature is expected to be released in version **1.2.1**
