### PR TITLE
1、restrict dockerImage tag to lowerCase;2、change the level of rollbac…

### DIFF
--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/fs/FsOperator.scala
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/fs/FsOperator.scala
@@ -62,4 +62,6 @@ abstract class FsOperator {
   def move(srcPath: String, dstPath: String): Unit
 
   def fileMd5(path: String): String
+
+  def download(srcPath: String, dstPath: String, delSrc: Boolean, useRawLocalFileSystem:Boolean): Unit
 }

--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/fs/HdfsOperator.scala
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/fs/HdfsOperator.scala
@@ -57,6 +57,9 @@ object HdfsOperator extends FsOperator with Logger {
     }
   }
 
+  override def download(srcPath: String, dstPath: String, delSrc: Boolean, useRawLocalFileSystem:Boolean): Unit=
+    HdfsUtils.download(toHdfsPath(srcPath),dstPath,delSrc,useRawLocalFileSystem)
+
 }
 
 

--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/fs/LFsOperator.scala
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/fs/LFsOperator.scala
@@ -105,6 +105,8 @@ object LFsOperator extends FsOperator with Logger {
     DigestUtils.md5Hex(IOUtils.toByteArray(new FileInputStream(path)))
   }
 
+  override def download(srcPath: String, dstPath: String, delSrc: Boolean, useRawLocalFileSystem: Boolean): Unit =
+    copyDir(srcPath, dstPath,delSrc=false, overwrite=true)
 }
 
 

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplicationBackUpServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplicationBackUpServiceImpl.java
@@ -201,12 +201,28 @@ public class ApplicationBackUpServiceImpl
                 // 回滚 config 和 sql
                 effectiveService.saveOrUpdate(backUp.getAppId(), EffectiveType.CONFIG, backUp.getId());
                 effectiveService.saveOrUpdate(backUp.getAppId(), EffectiveType.FLINKSQL, backUp.getSqlId());
-
+                String appHome = "";
+                switch (application.getExecutionModeEnum()) {
+                    case KUBERNETES_NATIVE_APPLICATION:
+                    case KUBERNETES_NATIVE_SESSION:
+                    case YARN_PRE_JOB:
+                    case YARN_SESSION:
+                    case LOCAL:
+                        if (application.isFlinkSqlJob()) {
+                            appHome = application.getLocalFlinkSqlHome().getAbsolutePath();
+                        } else {
+                            appHome = application.getDistHome();
+                        }
+                        break;
+                    case YARN_APPLICATION:
+                        appHome = application.getAppHome();
+                        break;
+                }
                 // 2) 删除当前项目
-                fsOperator.delete(application.getAppHome());
+                fsOperator.delete(appHome);
                 try {
                     // 5)将备份的文件copy到有效项目目录下.
-                    fsOperator.copyDir(backUp.getPath(), application.getAppHome());
+                    fsOperator.download(backUp.getPath(),appHome,false,false);
                 } catch (Exception e) {
                     throw e;
                 }

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplicationServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ApplicationServiceImpl.java
@@ -1049,143 +1049,139 @@ public class ApplicationServiceImpl extends ServiceImpl<ApplicationMapper, Appli
 
         //1) 真正执行启动相关的操作..
         String appConf, flinkUserJar;
-
-        //回滚任务.
-        if (application.isNeedRollback()) {
-            if (application.isFlinkSqlJob()) {
-                flinkSqlService.rollback(application);
-            }
-        }
-
-        //2) 将lastst的设置为Effective的,(此时才真正变成当前生效的)
-        this.toEffective(application);
-
-        //获取一个最新的Effective的配置
-        ApplicationConfig applicationConfig = configService.getEffective(application.getId());
-        ExecutionMode executionMode = ExecutionMode.of(application.getExecutionMode());
-
-        if (application.isCustomCodeJob()) {
-            assert executionMode != null;
-            switch (application.getApplicationType()) {
-                case STREAMX_FLINK:
-                    String format = applicationConfig.getFormat() == 1 ? "yaml" : "prop";
-                    appConf = String.format("%s://%s", format, applicationConfig.getContent());
-                    flinkUserJar = String.format("%s/lib/%s", application.getAppHome(), application.getModule().concat(".jar"));
-                    break;
-                case APACHE_FLINK:
-                    appConf = String.format("json://{\"%s\":\"%s\"}",
-                        ConfigurationOptions.KEY_APPLICATION_MAIN_CLASS,
-                        application.getMainClass()
-                    );
-                    flinkUserJar = String.format("%s/%s", application.getAppHome(), application.getJar());
-                    break;
-                default:
-                    throw new IllegalArgumentException("[StreamX] ApplicationType must be (StreamX flink | Apache flink)... ");
-            }
-        } else if (application.isFlinkSqlJob()) {
-            FlinkSql flinkSql = flinkSqlService.getEffective(application.getId(), false);
-            assert flinkSql != null;
-            this.flinkSqlService.cleanCandidate(flinkSql.getId());
-
-            //1) dist_userJar
-            File localPlugins = new File(WebUtils.getAppDir("plugins"));
-            assert localPlugins.exists();
-            List<String> jars =
-                Arrays.stream(Objects.requireNonNull(localPlugins.list())).filter(x -> x.matches("streamx-flink-sqlclient-.*\\.jar"))
-                    .collect(Collectors.toList());
-            if (jars.isEmpty()) {
-                throw new IllegalArgumentException("[StreamX] can no found streamx-flink-sqlclient jar in " + localPlugins);
-            }
-            if (jars.size() > 1) {
-                throw new IllegalArgumentException("[StreamX] found multiple streamx-flink-sqlclient jar in " + localPlugins);
-            }
-            String sqlDistJar = jars.get(0);
-            //2) appConfig
-            appConf = applicationConfig == null ? null : String.format("yaml://%s", applicationConfig.getContent());
-            assert executionMode != null;
-            //3) plugin
-            switch (executionMode) {
-                case YARN_PRE_JOB:
-                case KUBERNETES_NATIVE_SESSION:
-                case KUBERNETES_NATIVE_APPLICATION:
-                    flinkUserJar = Workspace.local().APP_PLUGINS().concat("/").concat(sqlDistJar);
-                    break;
-                case YARN_APPLICATION:
-                    String pluginPath = Workspace.remote().APP_PLUGINS();
-                    flinkUserJar = String.format("%s/%s", pluginPath, sqlDistJar);
-                    break;
-                default:
-                    throw new UnsupportedOperationException("Unsupported..." + executionMode);
-            }
-        } else {
-            throw new UnsupportedOperationException("Unsupported...");
-        }
-
-        StringBuilder option = new StringBuilder();
-        if (appParam.getAllowNonRestored()) {
-            option.append(" -n ");
-        }
-
-        String[] dynamicOption = CommonUtils.notEmpty(application.getDynamicOptions())
-            ? application.getDynamicOptions().split("\\s+")
-            : new String[0];
-
-        Map<String, Object> optionMap = application.getOptionMap();
-        optionMap.put(ConfigConst.KEY_JOB_ID(), application.getId());
-
-        JarPackDeps jarPackDeps;
-        if (application.isCustomCodeJob()) {
-            jarPackDeps = Application.Dependency.jsonToDependency(application.getDependency()).toJarPackDeps();
-        } else {
-            FlinkSql flinkSql = flinkSqlService.getEffective(application.getId(), false);
-            jarPackDeps = Application.Dependency.jsonToDependency(flinkSql.getDependency()).toJarPackDeps();
-            optionMap.put(ConfigConst.KEY_FLINK_SQL(null), flinkSql.getSql());
-        }
-
-        ResolveOrder resolveOrder = ResolveOrder.of(application.getResolveOrder());
-
-        KubernetesSubmitParam kubernetesSubmitParam = new KubernetesSubmitParam(
-            application.getClusterId(),
-            application.getFlinkImage(),
-            application.getK8sNamespace(),
-            jarPackDeps,
-            new DockerAuthConf(
-                settingService.getDockerRegisterAddress(),
-                settingService.getDockerRegisterUser(),
-                settingService.getDockerRegisterPassword()),
-            application.getK8sPodTemplates(),
-            application.getK8sRestExposedTypeEnum()
-        );
-
-        FlinkEnv flinkEnv = flinkEnvService.getByIdOrDefault(application.getVersionId());
-        if (flinkEnv == null) {
-            throw new IllegalArgumentException("[StreamX] can no found flink version");
-        }
-
-        SubmitRequest submitRequest = new SubmitRequest(
-            flinkEnv.getFlinkVersion(),
-            flinkEnv.getFlinkConf(),
-            flinkUserJar,
-            DevelopmentMode.of(application.getJobType()),
-            ExecutionMode.of(application.getExecutionMode()),
-            resolveOrder,
-            application.getJobName(),
-            appConf,
-            application.getApplicationType().getName(),
-            getSavePointed(appParam),
-            appParam.getFlameGraph() ? getFlameGraph(application) : null,
-            option.toString(),
-            optionMap,
-            dynamicOption,
-            application.getArgs(),
-            kubernetesSubmitParam
-        );
-
         ApplicationLog applicationLog = new ApplicationLog();
         applicationLog.setAppId(application.getId());
         applicationLog.setStartTime(new Date());
 
         try {
+            //回滚任务.
+            if (application.isNeedRollback()) {
+                if (application.isFlinkSqlJob()) {
+                    flinkSqlService.rollback(application);
+                }
+            }
+
+            //2) 将lastst的设置为Effective的,(此时才真正变成当前生效的)
+            this.toEffective(application);
+
+            //获取一个最新的Effective的配置
+            ApplicationConfig applicationConfig = configService.getEffective(application.getId());
+            ExecutionMode executionMode = ExecutionMode.of(application.getExecutionMode());
+
+            if (application.isCustomCodeJob()) {
+                assert executionMode != null;
+                switch (application.getApplicationType()) {
+                    case STREAMX_FLINK:
+                        String format = applicationConfig.getFormat() == 1 ? "yaml" : "prop";
+                        appConf = String.format("%s://%s", format, applicationConfig.getContent());
+                        flinkUserJar = String.format("%s/lib/%s", application.getAppHome(), application.getModule().concat(".jar"));
+                        break;
+                    case APACHE_FLINK:
+                        appConf = String.format("json://{\"%s\":\"%s\"}",
+                            ConfigurationOptions.KEY_APPLICATION_MAIN_CLASS,
+                            application.getMainClass()
+                        );
+                        flinkUserJar = String.format("%s/%s", application.getAppHome(), application.getJar());
+                        break;
+                    default:
+                        throw new IllegalArgumentException("[StreamX] ApplicationType must be (StreamX flink | Apache flink)... ");
+                }
+            } else if (application.isFlinkSqlJob()) {
+                FlinkSql flinkSql = flinkSqlService.getEffective(application.getId(), false);
+                assert flinkSql != null;
+                //1) dist_userJar
+                File localPlugins = new File(WebUtils.getAppDir("plugins"));
+                assert localPlugins.exists();
+                List<String> jars =
+                    Arrays.stream(Objects.requireNonNull(localPlugins.list())).filter(x -> x.matches("streamx-flink-sqlclient-.*\\.jar"))
+                        .collect(Collectors.toList());
+                if (jars.isEmpty()) {
+                    throw new IllegalArgumentException("[StreamX] can no found streamx-flink-sqlclient jar in " + localPlugins);
+                }
+                if (jars.size() > 1) {
+                    throw new IllegalArgumentException("[StreamX] found multiple streamx-flink-sqlclient jar in " + localPlugins);
+                }
+                String sqlDistJar = jars.get(0);
+                //2) appConfig
+                appConf = applicationConfig == null ? null : String.format("yaml://%s", applicationConfig.getContent());
+                assert executionMode != null;
+                //3) plugin
+                switch (executionMode) {
+                    case YARN_PRE_JOB:
+                    case KUBERNETES_NATIVE_SESSION:
+                    case KUBERNETES_NATIVE_APPLICATION:
+                        flinkUserJar = Workspace.local().APP_PLUGINS().concat("/").concat(sqlDistJar);
+                        break;
+                    case YARN_APPLICATION:
+                        String pluginPath = Workspace.remote().APP_PLUGINS();
+                        flinkUserJar = String.format("%s/%s", pluginPath, sqlDistJar);
+                        break;
+                    default:
+                        throw new UnsupportedOperationException("Unsupported..." + executionMode);
+                }
+            } else {
+                throw new UnsupportedOperationException("Unsupported...");
+            }
+
+            StringBuilder option = new StringBuilder();
+            if (appParam.getAllowNonRestored()) {
+                option.append(" -n ");
+            }
+
+            String[] dynamicOption = CommonUtils.notEmpty(application.getDynamicOptions())
+                ? application.getDynamicOptions().split("\\s+")
+                : new String[0];
+
+            Map<String, Object> optionMap = application.getOptionMap();
+            optionMap.put(ConfigConst.KEY_JOB_ID(), application.getId());
+
+            JarPackDeps jarPackDeps;
+            if (application.isCustomCodeJob()) {
+                jarPackDeps = Application.Dependency.jsonToDependency(application.getDependency()).toJarPackDeps();
+            } else {
+                FlinkSql flinkSql = flinkSqlService.getEffective(application.getId(), false);
+                jarPackDeps = Application.Dependency.jsonToDependency(flinkSql.getDependency()).toJarPackDeps();
+                optionMap.put(ConfigConst.KEY_FLINK_SQL(null), flinkSql.getSql());
+            }
+
+            ResolveOrder resolveOrder = ResolveOrder.of(application.getResolveOrder());
+
+            KubernetesSubmitParam kubernetesSubmitParam = new KubernetesSubmitParam(
+                application.getClusterId(),
+                application.getFlinkImage(),
+                application.getK8sNamespace(),
+                jarPackDeps,
+                new DockerAuthConf(
+                    settingService.getDockerRegisterAddress(),
+                    settingService.getDockerRegisterUser(),
+                    settingService.getDockerRegisterPassword()),
+                application.getK8sPodTemplates(),
+                application.getK8sRestExposedTypeEnum()
+            );
+
+            FlinkEnv flinkEnv = flinkEnvService.getByIdOrDefault(application.getVersionId());
+            if (flinkEnv == null) {
+                throw new IllegalArgumentException("[StreamX] can no found flink version");
+            }
+
+            SubmitRequest submitRequest = new SubmitRequest(
+                flinkEnv.getFlinkVersion(),
+                flinkEnv.getFlinkConf(),
+                flinkUserJar,
+                DevelopmentMode.of(application.getJobType()),
+                ExecutionMode.of(application.getExecutionMode()),
+                resolveOrder,
+                application.getJobName(),
+                appConf,
+                application.getApplicationType().getName(),
+                getSavePointed(appParam),
+                appParam.getFlameGraph() ? getFlameGraph(application) : null,
+                option.toString(),
+                optionMap,
+                dynamicOption,
+                application.getArgs(),
+                kubernetesSubmitParam
+            );
 
             SubmitResponse submitResponse = FlinkSubmitHelper.submit(submitRequest);
 

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/FlinkSqlServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/FlinkSqlServiceImpl.java
@@ -157,21 +157,27 @@ public class FlinkSqlServiceImpl extends ServiceImpl<FlinkSqlMapper, FlinkSql> i
     }
 
     @Override
+    @Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRES_NEW)
     public void rollback(Application application) {
         FlinkSql sql = getCandidate(application.getId(), CandidateType.HISTORY);
         assert sql != null;
-
-        //检查并备份当前的任务.
-        FlinkSql effectiveSql = getEffective(application.getId(), false);
-        assert effectiveSql != null;
-        if (!isFlinkSqlBacked(effectiveSql)) {
-            log.info("current job version:{}, Backing up...", sql.getVersion());
-            backUpService.backup(application);
-        } else {
-            log.info("current job version:{}, already backed", sql.getVersion());
+        try {
+            //检查并备份当前的任务.
+            FlinkSql effectiveSql = getEffective(application.getId(), false);
+            assert effectiveSql != null;
+            if (!isFlinkSqlBacked(effectiveSql)) {
+                log.info("current job version:{}, Backing up...", sql.getVersion());
+                backUpService.backup(application);
+            } else {
+                log.info("current job version:{}, already backed", sql.getVersion());
+            }
+            //回滚历史版本的任务
+            backUpService.rollbackFlinkSql(application, sql);
+        } catch (Throwable e) {
+            log.error("[streamx] Backup and Roll back before start is not succeed.{}",ExceptionUtils.stringifyException(e));
+            throw new RuntimeException(e.getMessage());
         }
-        //回滚历史版本的任务
-        backUpService.rollbackFlinkSql(application, sql);
+
     }
 
     @Override

--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/K8sFlinkChangeEventListener.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/task/K8sFlinkChangeEventListener.java
@@ -93,7 +93,7 @@ public class K8sFlinkChangeEventListener {
         if (ExecutionMode.KUBERNETES_NATIVE_SESSION.equals(mode)) {
             query.eq("job_id", jobStatus.jobId());
         }
-        query.orderByDesc("create_time");
+        query.orderByDesc("create_time").last("limit 1");
         Application app = applicationService.getOne(query);
         if (app == null) {
             return;

--- a/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/docker/DockerTool.scala
+++ b/streamx-plugin/streamx-flink-packer/src/main/scala/com/streamxhub/streamx/flink/packer/docker/DockerTool.scala
@@ -113,8 +113,8 @@ object DockerTool extends Logger {
    */
   def formatTag(tag: String, registerAddress: String): String = {
     if (registerAddress.nonEmpty && !tag.startsWith(registerAddress)) {
-      s"$registerAddress${if (tag.contains("/")) "/" else "/library/"}$tag"
-    } else tag
+      s"$registerAddress${if (tag.contains("/")) "/" else "/library/"}$tag".toLowerCase()
+    } else tag.toLowerCase()
   }
 
 


### PR DESCRIPTION
PR Title Format:

1、Deal with the exception caused by getOne when two or more (same clusterId and same namespace) rows appears in t_flink_app.
2、Docker-image name need to be lowerCase.
3、Change the Level of Transactional to REQUIRES_NEW to avoid too many directory and jars while build jar or DockerImages failed next step.
4、Expand the try-catch Scope to avoid no-change-state caused by not-catched Exception.