### PR TITLE
[hotfix] Ignore package-lock.json

### DIFF
--- a/streamx-console/streamx-console-webapp/.gitignore
+++ b/streamx-console/streamx-console-webapp/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 dist/
 node/
+package-lock.json


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

After execute mvn package, the node will generate `package-lock.json` automatically.

```
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        streamx-console/streamx-console-webapp/package-lock.json
```

### What is changed and how it works?

Add `package-lock.json` to .gitignore file.
