### PR TITLE
[hotfix] fix specified key too long

### DIFF
--- a/streamx-console/streamx-console-service/src/main/resources/db/migration/V1_2__upgrade_db.sql
+++ b/streamx-console/streamx-console-service/src/main/resources/db/migration/V1_2__upgrade_db.sql
@@ -6,7 +6,7 @@ SET FOREIGN_KEY_CHECKS = 0;
 DROP TABLE IF EXISTS `t_flink_env`;
 CREATE TABLE `t_flink_env` (
 `ID` bigint NOT NULL AUTO_INCREMENT COMMENT 'ID',
-`FLINK_NAME` varchar(255) NOT NULL COMMENT 'Flink实例名称',
+`FLINK_NAME` varchar(128) NOT NULL COMMENT 'Flink实例名称',
 `FLINK_HOME` varchar(255) NOT NULL COMMENT 'Flink Home路径',
 `VERSION` varchar(50) NOT NULL COMMENT 'Flink对应的版本号',
 `SCALA_VERSION` varchar(50) NOT NULL COMMENT 'Flink对应的scala版本号',


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

run the streamx-console failed, 
```
Message    : Specified key was too long; max key length is 767 bytes
Location   : db/migration/V1_2__upgrade_db.sql (/work/projects/opensource/streamx/streamx-console/streamx-console-service/target/streamx-console-service-1.2.1/file:/work/projects/opensource/streamx/streamx-console/streamx-console-service/target/streamx-console-service-1.2.1/lib/streamx-console-service-1.2.1.jar!/db/migration/V1_2__upgrade_db.sql)
Line       : 7
Statement  : CREATE TABLE `t_flink_env` (
`ID` bigint NOT NULL AUTO_INCREMENT COMMENT 'ID',
`FLINK_NAME` varchar(255) NOT NULL COMMENT 'Flink实例名称',
`FLINK_HOME` varchar(255) NOT NULL COMMENT 'Flink Home路径',
`VERSION` varchar(50) NOT NULL COMMENT 'Flink对应的版本号',
`SCALA_VERSION` varchar(50) NOT NULL COMMENT 'Flink对应的scala版本号',
`FLINK_CONF` text NOT NULL COMMENT 'flink-conf配置内容',
`IS_DEFAULT` tinyint NOT NULL DEFAULT '0' COMMENT '是否为默认版本',
`DESCRIPTION` varchar(255) DEFAULT NULL COMMENT '描述信息',
`CREATE_TIME` datetime NOT NULL COMMENT '创建时间',
PRIMARY KEY (`ID`) USING BTREE,
UNIQUE KEY `UN_NAME` (`FLINK_NAME`) USING BTREE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci

        at org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor.handleException(DefaultSqlScriptExecutor.java:253)
        at org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor.executeStatement(DefaultSqlScriptExecutor.java:202)
        at org.flywaydb.core.internal.sqlscript.DefaultSqlScriptExecutor.execute(DefaultSqlScriptExecutor.java:125)
```

reference:
https://blog.csdn.net/hfut_wowo/article/details/88018800

### What is changed and how it works?

varchar(128) is enough to meet the requirements of the field `FLINK_NAME`.