### PR TITLE
fix bug: wrong jar file chosen when building

### DIFF
--- a/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ProjectServiceImpl.java
+++ b/streamx-console/streamx-console-service/src/main/java/com/streamxhub/streamx/console/core/service/impl/ProjectServiceImpl.java
@@ -233,7 +233,7 @@ public class ProjectServiceImpl extends ServiceImpl<ProjectMapper, Project>
                             jar = targetFile;
                         } else {
                             // 可能存在会找到多个jar,这种情况下,选择体积最大的那个jar返回...(不要问我为什么.)
-                            if (targetFile.getTotalSpace() > jar.getTotalSpace()) {
+                            if (targetFile.length() > jar.length()) {
                                 jar = targetFile;
                             }
                         }


### PR DESCRIPTION
<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
https://github.com/streamxhub/streamx/issues/471
Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
when building a project,it did't chose the biggest jar
### What is changed and how it works?
change the jar.getTotalSpace to file.length
Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

