### PR TITLE
Support remote hdfs workspace path with scheme or without 

### DIFF
--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/conf/Workspace.scala
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/conf/Workspace.scala
@@ -50,9 +50,11 @@ case class Workspace(storageType: StorageType) {
           case null =>
             s"${HdfsUtils.getDefaultFS}$STREAMX_WORKSPACE_DEFAULT"
           case p =>
-            require(p.startsWith("hdfs://"), "")
-            val path = p.replaceFirst("^hdfs://((.*):\\d+/+|/+|)", "/")
-            s"${HdfsUtils.getDefaultFS}$path"
+            if(p.startsWith("hdfs")){
+              p
+            } else {
+              s"${HdfsUtils.getDefaultFS}$p"
+            }
         }
     }
   }

--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/conf/Workspace.scala
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/conf/Workspace.scala
@@ -22,6 +22,8 @@ import com.streamxhub.streamx.common.conf.ConfigConst._
 import com.streamxhub.streamx.common.enums.StorageType
 import com.streamxhub.streamx.common.util.{HdfsUtils, SystemPropertyUtils}
 
+import java.net.URI
+
 /**
  * @author benjobs
  * @param storageType
@@ -50,8 +52,14 @@ case class Workspace(storageType: StorageType) {
           case null =>
             s"${HdfsUtils.getDefaultFS}$STREAMX_WORKSPACE_DEFAULT"
           case p =>
-            if(p.startsWith("hdfs")){
-              p
+            var defaultFs = ${HdfsUtils.getDefaultFS}
+            if (p.startsWith("hdfs://")) {
+              if (p.startsWith(defaultFs)) {
+                p
+              } else {
+                var path = URI.create(p).getPath
+                s"${HdfsUtils.getDefaultFS}$path"
+              }
             } else {
               s"${HdfsUtils.getDefaultFS}$p"
             }

--- a/streamx-common/src/main/scala/com/streamxhub/streamx/common/conf/Workspace.scala
+++ b/streamx-common/src/main/scala/com/streamxhub/streamx/common/conf/Workspace.scala
@@ -52,7 +52,7 @@ case class Workspace(storageType: StorageType) {
           case null =>
             s"${HdfsUtils.getDefaultFS}$STREAMX_WORKSPACE_DEFAULT"
           case p =>
-            var defaultFs = ${HdfsUtils.getDefaultFS}
+            var defaultFs = HdfsUtils.getDefaultFS
             if (p.startsWith("hdfs://")) {
               if (p.startsWith(defaultFs)) {
                 p

--- a/streamx-console/streamx-console-service/src/main/resources/application.yml
+++ b/streamx-console/streamx-console-service/src/main/resources/application.yml
@@ -71,7 +71,7 @@ streamx:
   # 本地的工作空间,用于存放项目源码,构建的目录等.
   workspace:
     local: ~/streamx_workspace
-    remote: hdfs://streamx
+    remote: hdfs:///streamx   # support hdfs:///streamx/ 、 /streamx 、hdfs://host:ip/streamx/
 
   # remote docker register namepsace for streamx
   docker:


### PR DESCRIPTION
Support remote hdfs workspace path with scheme or without  , like hdfs://hadoopcluster/streamx/ or /streamx/

<!-- Thank you for contributing to StreamX 😃!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

